### PR TITLE
Plasmaman Command Sprites

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -589,6 +589,7 @@
 #include "code\FulpstationCode\wintercoats.dm"
 #include "code\FulpstationCode\halloween_costumes\joseph_joestar.dm"
 #include "code\FulpstationCode\halloween_costumes\outfits.dm"
+#include "code\FulpstationCode\halloween_costumes\phantom_maid.dm"
 #include "code\FulpstationCode\halloween_costumes\solid_snake.dm"
 #include "code\FulpstationCode\halloween_costumes\starship_troopers.dm"
 #include "code\game\alternate_appearance.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the following:
CE plasmaman suit and Helmet
CMO plasmaman suit and Helmet
RD plasmaman suit and Helmet
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This update will help players be able to differentiate between command plasmemes and assistant plasmemes, considering they use the same sprite at the moment. The current sprite is also eye cancer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

![command-Plasmaman](https://user-images.githubusercontent.com/44308186/66361798-3789a800-e94e-11e9-98c1-1ee4e41c33c3.png)
## Changelog
:cl:
add: new plasmaman suits for command
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
